### PR TITLE
build: fix gradle deprecations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -201,10 +201,10 @@ task codeCoverage(type: JacocoReport, group: 'verification') {
     }
 
     reports {
-        xml.enabled true
+        xml.required.set(true)
         xml.destination new File("${buildDir}/reports/jacoco/report.xml")
-        html.enabled true
-        csv.enabled false
+        html.required.set(true)
+        csv.required.set(false)
     }
 }
 

--- a/ktlint.gradle
+++ b/ktlint.gradle
@@ -1,5 +1,5 @@
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 configurations {
@@ -12,14 +12,14 @@ dependencies {
 task checkStyle(type: JavaExec, group: "klint") {
     description = "Check Kotlin code style."
     classpath = configurations.ktlint
-    main = "com.pinterest.ktlint.Main"
+    mainClass = "com.pinterest.ktlint.Main"
     args "src/**/*.kt"
 }
 
 task fixStyle(type: JavaExec, group: "klint") {
     description = "Fix Kotlin code style deviations."
     classpath = configurations.ktlint
-    main = "com.pinterest.ktlint.Main"
+    mainClass = "com.pinterest.ktlint.Main"
     args "-F", "src/**/*.kt"
 }
 
@@ -27,6 +27,6 @@ task configureIntellij(type: JavaExec, group: "klint"){
     description = "Configure intellij"
     classpath = configurations.ktlint
     workingDir = project.rootDir
-    main = "com.pinterest.ktlint.Main"
+    mainClass = "com.pinterest.ktlint.Main"
     args "--apply-to-idea-project", "--android", "-y"
 }


### PR DESCRIPTION
Gradle 7.1 is reporting some deprecations that will break build with
gradle ≥ 8. Fix the deprecations with the new replacements.
See the following links for details:
https://docs.gradle.org/7.1/userguide/upgrading_version_6.html#jcenter_deprecation
https://docs.gradle.org/7.1/dsl/org.gradle.api.tasks.JavaExec.html#org.gradle.api.tasks.JavaExec:main
https://docs.gradle.org/7.1/dsl/org.gradle.api.reporting.Report.html#org.gradle.api.reporting.Report:enabled

Signed-off-by: Diego Rondini <diego.rondini@kynetics.com>