### PR TITLE
Fix jitpack build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,14 @@ subprojects {
         implementation deps.kotlin_x
         //runtime deps.kotlin_compiler
     }
+
+    publishing {
+        publications {
+            mavenJava(MavenPublication) {
+                from components.java
+            }
+        }
+    }
 }
 
 project(':ddiapi-client') {


### PR DESCRIPTION
Jitpack build fails with ERROR: No build artifacts found.
Fixed configuring publishing section in build.gradle