### PR TITLE
Fix tests on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+docker/test/artifactrepo/** binary


### PR DESCRIPTION
The git client of windows replaces the \n with \n\r in all files
in ./docker/test/artifactrepo. This also updates the md5 so
the tests fail when the md5 is checked (the md5 of the files are different from
the value stores as metadata in the db).